### PR TITLE
Fix broken DRM decode

### DIFF
--- a/src/drmrx/sourcedecoder.cpp
+++ b/src/drmrx/sourcedecoder.cpp
@@ -342,6 +342,7 @@ bool sourceDecoder::addHeaderSegment()
 
   while(currentDataPacket.ba.count())
     {
+      dataPtr=(unsigned char *)currentDataPacket.ba.data();
       PLI=dataPtr[0]>>6;
       paramID=dataPtr[0]&0x3F;
       switch (PLI)


### PR DESCRIPTION
Pick up start of currentDataPacket.ba not only once but after each advance() operation.
Qt documentation states that an address of a QByteArray obtained by ba.data() gets invalidaded by an remove() actioni (part of advance() ). With Qt5 it seems to work by accident, but fails with Qt6.